### PR TITLE
Set ExpressionLanguage cache engine to default

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -36,7 +36,8 @@ return function (ContainerConfigurator $configurator) {
     $services->load('SprykerSdk\\', '../src/')
         ->exclude('../src/{DependencyInjection,Tests,Kernel.php}');
 
-    $services->set(ExpressionLanguage::class);
+    $services->set(ExpressionLanguage::class)
+        ->args([null, []]);
 
     // Make SprykFactory public for instantiating the SprykFacade from external packages like `spryker-sdk/spryk-gui`
     $services->get(SprykFactory::class)->public();


### PR DESCRIPTION
- Developer(s): @yaroslav-spryker 

- Ticket: URL_HERE

- Docs PR: ACADEMY_URL_HERE

- Release Group: URL_HERE

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykSrc              | patch |                       |

-----------------------------------------

#### Module SprykSrc

##### Changelog

### Improvements

- Updated setting cache driver for `ExpressionLanguage` to default adapter.
