### PR TITLE
Remove trailing slashes from codeception paths

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -1,6 +1,7 @@
 namespace: SprykerSdkTest
 
 paths:
+    # paths should not end with slashes, see https://github.com/spryker-sdk/spryk-src/pull/47
     tests: tests
     log: tests/_output
     data: tests/_data

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,11 +1,11 @@
 namespace: SprykerSdkTest
 
 paths:
-    tests: tests/
-    log: tests/_output/
-    data: tests/_data/
-    support: tests/_support/
-    envs: tests/_envs/
+    tests: tests
+    log: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
 
 bootstrap: bootstrap.php
 


### PR DESCRIPTION
- Developer(s): @k4emic

- Ticket: https://spryker.atlassian.net/browse/APPS-4625 (unrelated, discovered while working on it)

- Docs PR: N/A

- Release Group: N/A

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykSrc              | patch {skip} (currently 0.0.x)  |                       |

---
This is a quality-of-life change for running tests more easily. There are no functional changes to the project.

Running individual test files doesn't currently work. This means we have to run the entire test suite while working on a specific topic.

```
php vendor/bin/codecept run tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php -q

In Run.php line 643:
                              
  Test file can't be matched  

```                           

If the test path contains double slashes, it works:
```
php vendor/bin/codecept run tests//SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php -q


Time: 00:15.626, Memory: 60.50 MB

OK (6 tests, 165 assertions)

```

The regex pattern on this line indicates that slashes should not be included in the test path: https://github.com/Codeception/Codeception/blob/4.2.1/src/Codeception/Command/Run.php#L640

The official docs does not use trailing slashes in the example: https://codeception.com/docs/reference/Configuration#paths

Removing the trailing slash allows us to run individual tests
```
php vendor/bin/codecept run tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php -q


Time: 00:15.568, Memory: 60.50 MB

OK (6 tests, 165 assertions)

```





