### PR TITLE
Bugfix/apps 4625 syncapi code builder breaks when using a reference to a defined endpoints http method

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,13 @@ return function (ContainerConfigurator $configurator) {
     $services->load('SprykerSdk\\', '../src/')
         ->exclude('../src/{DependencyInjection,Tests,Kernel.php}');
 
+    $services->load('Laminas\\Filter\\', __DIR__ . '/../vendor/laminas/laminas-filter/src/')
+        ->exclude([
+            # these depend on Laminas' service managers
+            __DIR__ . '/../vendor/laminas/laminas-filter/src/{*Factory,FilterPluginManager}.php',
+            __DIR__ . '/../vendor/laminas/laminas-filter/src/**/*Factory.php',
+        ]);
+
     $services->set(ExpressionLanguage::class)
         ->args([null, []]);
 

--- a/config/spryk/spryks/Spryker/Glue/AddGlueResourceMethodResponse.yml
+++ b/config/spryk/spryks/Spryker/Glue/AddGlueResourceMethodResponse.yml
@@ -10,7 +10,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule: # dataModule
@@ -55,15 +55,15 @@ arguments:
         description: "The HTTP response code e.g. 200 (OK)"
 
     controller:
-        default: "{{ resource | normalizeResourceName }}ResourceController"
+        default: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        default: "{{ resource | normalizeResourceName | singularize }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        default: "{{ resource | normalizeResourceName | singularize }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
 postSpryks:
     - AddGlueBackendApiApplication

--- a/config/spryk/spryks/Spryker/Glue/AddGlueResourceMethodResponse.yml
+++ b/config/spryk/spryks/Spryker/Glue/AddGlueResourceMethodResponse.yml
@@ -10,7 +10,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule: # dataModule
@@ -55,15 +55,15 @@ arguments:
         description: "The HTTP response code e.g. 200 (OK)"
 
     controller:
-        default: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        default: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        default: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        default: "{{ resource | resourceNameToModelName | singularize }}"
 
 postSpryks:
     - AddGlueBackendApiApplication

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiController.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiController.yml
@@ -9,7 +9,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -40,7 +40,7 @@ arguments:
 
     controller:
         inherit: true
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
 postSpryks:
     - AddClass:

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiController.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiController.yml
@@ -9,7 +9,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -40,7 +40,7 @@ arguments:
 
     controller:
         inherit: true
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
 postSpryks:
     - AddClass:

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDelete.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDelete.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/DeleteMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDelete.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDelete.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/DeleteMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDeleteCollection.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDeleteCollection.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/DeleteCollectionMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDeleteCollection.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodDeleteCollection.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/DeleteCollectionMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGet.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGet.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/GetMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGet.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGet.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/GetMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetCollection.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetCollection.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/GetCollectionMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetCollection.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetCollection.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/GetCollectionMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPatch.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPatch.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/PatchMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPatch.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPatch.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/PatchMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
+        value: "{{ resource | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/PostMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
@@ -48,7 +48,7 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName |  resourceNameToControllerName }}ResourceController"
+        value: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodPost.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Based on the applicationType the module name will be suffixed with BackendApi or FrontendApi by the ResourceModuleName callback."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     dataModule:
@@ -48,15 +48,15 @@ arguments:
     controller:
         inherit: true
         description: "Defines the Controller name to use."
-        value: "{{ resource | normalizeResourceName }}ResourceController"
+        value: "{{ resource | normalizeResourceName |  resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Controller. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)."
-        value: "{{ resource | normalizeResourceName }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}"
 
     target:
         value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ controller | classNameShort | ensureControllerSuffix }}"
@@ -86,7 +86,7 @@ postSpryks:
               body:
                   value: Glue/BackendApi/Controller/PostMethod.php.twig
               target:
-                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                  value: "{{ organization }}\\Glue\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               withInterface:
                   value: false
 

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiRequestMapper.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiRequestMapper.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Module name should be suffixed either with Api or with BackendApi depending on the choosen applicationType."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
 
     organization:
         inherit: true
@@ -41,14 +41,14 @@ arguments:
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Methods. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)"
         isOptional: true # Is not needed for all methods
-        default: "{{ resource | normalizeResourceName | singularize }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     template:
         value: Common/Class.php.twig
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        default: "{{ resource | normalizeResourceName | singularize }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     implements:
         value: "\\{{ organization }}\\Glue\\{{ module }}\\Mapper\\GlueRequest{{ resourceDataObject }}MapperInterface"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiRequestMapper.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiRequestMapper.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Module name should be suffixed either with Api or with BackendApi depending on the choosen applicationType."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
+        default: "{{ resource | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
 
     organization:
         inherit: true
@@ -41,14 +41,14 @@ arguments:
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Methods. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)"
         isOptional: true # Is not needed for all methods
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        default: "{{ resource | resourceNameToModelName | singularize }}"
 
     template:
         value: Common/Class.php.twig
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        default: "{{ resource | resourceNameToModelName | singularize }}"
 
     implements:
         value: "\\{{ organization }}\\Glue\\{{ module }}\\Mapper\\GlueRequest{{ resourceDataObject }}MapperInterface"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiResponseMapper.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiResponseMapper.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Module name should be suffixed either with Api or with BackendApi depending on the choosen applicationType."
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
+        default: "{{ resource | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
 
     organization:
         inherit: true
@@ -40,14 +40,14 @@ arguments:
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Methods. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)"
         isOptional: true # Is not needed for all methods
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     template:
         value: Common/Class.php.twig
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
+        value: "{{ resource | resourceNameToModelName | singularize }}"
 
     implements:
         value: "\\{{ organization }}\\Glue\\{{ module }}\\Mapper\\GlueResponse{{ resourceDataObject }}MapperInterface"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiResponseMapper.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Mapper/AddGlueBackendApiResponseMapper.yml
@@ -7,7 +7,7 @@ arguments:
     module:
         description: "Module name should be suffixed either with Api or with BackendApi depending on the choosen applicationType."
         inherit: true
-        default: "{{ resource | normalizeResourceName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{% if applicationType == 'Frontend' %}Api{% else %}BackendApi{% endif %}"
 
     organization:
         inherit: true
@@ -40,14 +40,14 @@ arguments:
     resourceDataObject:
         description: "Defines the Transfer that will be used in the Methods. Do not use Transfer as suffix, it will be added automatically. Example: Customer (ok) CustomerTransfer (wrong)"
         isOptional: true # Is not needed for all methods
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     template:
         value: Common/Class.php.twig
 
     zedDomainEntity:
         description: "Defines the domainEntity used on Zed side for the CRUD Facade. It will be used to create all needed Transfer Objects."
-        value: "{{ resource | normalizeResourceName | singularize }}"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}"
 
     implements:
         value: "\\{{ organization }}\\Glue\\{{ module }}\\Mapper\\GlueResponse{{ resourceDataObject }}MapperInterface"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddBackendApiResourceMethod.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddBackendApiResourceMethod.yml
@@ -5,7 +5,7 @@ mode: both
 arguments:
     module:
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -37,7 +37,7 @@ arguments:
 
     className:
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}BackendApiResource"
+        default: "{{ resource | resourceNameToModelName }}BackendApiResource"
 
     target:
         value: "\\{{ organization }}\\{{ application }}\\{{ module }}\\Plugin\\{{ className }}"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddBackendApiResourceMethod.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddBackendApiResourceMethod.yml
@@ -5,7 +5,7 @@ mode: both
 arguments:
     module:
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -37,7 +37,7 @@ arguments:
 
     className:
         inherit: true
-        default: "{{ resource | normalizeResourceName }}BackendApiResource"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}BackendApiResource"
 
     target:
         value: "\\{{ organization }}\\{{ application }}\\{{ module }}\\Plugin\\{{ className }}"

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddGlueBackendApiResourcePlugin.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddGlueBackendApiResourcePlugin.yml
@@ -5,7 +5,7 @@ mode: both
 arguments:
     module:
         inherit: true
-        default: "{{ resource | normalizeResourceName }}"
+        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -27,7 +27,7 @@ arguments:
         inherit: true
 
     className:
-        default: "{{ resource | normalizeResourceName }}BackendApiResource"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}BackendApiResource"
 
     extends:
         callback: ResolveExtends
@@ -69,12 +69,12 @@ postSpryks:
                   value: "getController"
               annotations:
                   value:
-                      - "@uses \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController"
+                      - "@uses \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
               output:
                   value: "string"
               body:
                   value:
-                      - "return \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName }}ResourceController::class;"
+                      - "return \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController::class;"
               target:
                   value: "\\{{ organization }}\\Glue\\{{ module }}\\Plugin\\{{ className }}"
               withInterface:

--- a/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddGlueBackendApiResourcePlugin.yml
+++ b/config/spryk/spryks/Spryker/Glue/BackendApi/Plugin/AddGlueBackendApiResourcePlugin.yml
@@ -5,7 +5,7 @@ mode: both
 arguments:
     module:
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModuleName }}"
+        default: "{{ resource | resourceNameToModuleName }}"
         callback: GlueResourceModuleName
 
     organization:
@@ -27,7 +27,7 @@ arguments:
         inherit: true
 
     className:
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}BackendApiResource"
+        default: "{{ resource | resourceNameToModelName }}BackendApiResource"
 
     extends:
         callback: ResolveExtends
@@ -69,12 +69,12 @@ postSpryks:
                   value: "getController"
               annotations:
                   value:
-                      - "@uses \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+                      - "@uses \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController"
               output:
                   value: "string"
               body:
                   value:
-                      - "return \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController::class;"
+                      - "return \\{{ organization }}\\{{ application }}\\{{ module }}\\Controller\\{{ resource | resourceNameToControllerName }}ResourceController::class;"
               target:
                   value: "\\{{ organization }}\\Glue\\{{ module }}\\Plugin\\{{ className }}"
               withInterface:

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestApiCest.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestApiCest.yml
@@ -15,7 +15,7 @@ arguments:
         default: false
 
     module:
-        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
+        value: "{{ resource | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -50,7 +50,7 @@ arguments:
 
     className:
         inherit: true
-        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+        default: "{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
 
     targetFilename:
         value: "{{ className }}.php"
@@ -59,7 +59,7 @@ arguments:
         value: "tests/{{ organization }}Test/{{ application }}/{{ module }}/{{suite | ucfirst}}"
 
     fixtureClass:
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
+        value: "{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
 
 preSpryks:
     - AddGlueTestHelper
@@ -81,15 +81,15 @@ postSpryks:
               httpMethod:
                   inherit: true
               method:
-                  value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                  value: "request{{ resource | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
               input:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
               output:
                  value: "void"
               body:
                   value: Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
               target:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
               withInterface:
                   value: false
 
@@ -107,15 +107,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -133,15 +133,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize | ucfirst }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | resourceNameToModelName | singularize | ucfirst }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/DeleteCollectionCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -159,15 +159,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -185,15 +185,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -211,14 +211,14 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestApiCest.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestApiCest.yml
@@ -15,7 +15,7 @@ arguments:
         default: false
 
     module:
-        value: "{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api"
+        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -50,7 +50,7 @@ arguments:
 
     className:
         inherit: true
-        default: "{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+        default: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
 
     targetFilename:
         value: "{{ className }}.php"
@@ -59,7 +59,7 @@ arguments:
         value: "tests/{{ organization }}Test/{{ application }}/{{ module }}/{{suite | ucfirst}}"
 
     fixtureClass:
-        value: "{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
 
 preSpryks:
     - AddGlueTestHelper
@@ -81,15 +81,15 @@ postSpryks:
               httpMethod:
                   inherit: true
               method:
-                  value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                  value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
               input:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
               output:
                  value: "void"
               body:
                   value: Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
               target:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
               withInterface:
                   value: false
 
@@ -107,15 +107,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -133,15 +133,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize | ucfirst }}{{ httpMethod | ucfirst }}CollectionReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/DeleteCollectionCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -159,15 +159,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -185,15 +185,15 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false
 
@@ -211,14 +211,14 @@ postSpryks:
             httpMethod:
                 inherit: true
             method:
-                value: "request{{ resource | normalizeResourceName | singularize | ucfirst }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
+                value: "request{{ resource | normalizeResourceName | resourceNameToModelName | singularize }}{{ httpMethod | ucfirst }}ReturnsHttpResponseCode{{ httpResponseCode }}"
             input:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I"
             output:
                 value: "void"
             body:
                 value: Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{suite | ucfirst}}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Cest"
             withInterface:
                 value: false

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestCodeceptionConfiguration.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestCodeceptionConfiguration.yml
@@ -4,7 +4,7 @@ mode: both
 
 arguments:
     module:
-        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
+        value: "{{ resource | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestCodeceptionConfiguration.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestCodeceptionConfiguration.yml
@@ -4,7 +4,7 @@ mode: both
 
 arguments:
     module:
-        value: "{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api"
+        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestFixtures.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestFixtures.yml
@@ -10,7 +10,7 @@ arguments:
         description: "Defines the resource name this controller will work with e.g. /customers"
 
     module:
-        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
+        value: "{{ resource | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -45,7 +45,7 @@ arguments:
         value: Glue/Test/GlueTestFixtures/TestFixtures.php.twig
 
     className:
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
+        value: "{{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
 
     targetFilename:
         value: "{{ className }}.php"

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestFixtures.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestFixtures.yml
@@ -10,7 +10,7 @@ arguments:
         description: "Defines the resource name this controller will work with e.g. /customers"
 
     module:
-        value: "{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api"
+        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -45,7 +45,7 @@ arguments:
         value: Glue/Test/GlueTestFixtures/TestFixtures.php.twig
 
     className:
-        value: "{{ resource | normalizeResourceName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{% if isBulk.value == true %}Collection{% endif %}{{ suite }}Fixtures"
 
     targetFilename:
         value: "{{ className }}.php"

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestHelper.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestHelper.yml
@@ -51,7 +51,7 @@ arguments:
         description: "The response code e.g. 200"
 
     controller:
-        default: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
+        default: "{{ resource | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         inherit: true
@@ -64,7 +64,7 @@ postSpryks:
     - AddTestHelper:
         arguments:
             className:
-                value: "{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
+                value: "{{ resource | resourceNameToModelName }}Helper"
         excludedSpryks:
             - EnableTestHelper
 
@@ -75,15 +75,15 @@ postSpryks:
               isBulk:
                   inherit: true
               method:
-                  value: "build{{ resource | normalizeResourceName | resourceNameToModelName }}Url"
+                  value: "build{{ resource | resourceNameToModelName }}Url"
               input:
                   value: "?int ${{ zedDomainEntity | lcfirst }}Identifier = null"
               output:
                   value: string
               body:
-                  value: "return ${{ zedDomainEntity | lcfirst }}Identifier !== null ? $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | lcfirst }}/{id}', ['id' => ${{ zedDomainEntity | lcfirst }}Identifier]) : $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | resourceNameToModelName }}');"
+                  value: "return ${{ zedDomainEntity | lcfirst }}Identifier !== null ? $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | lcfirst }}/{id}', ['id' => ${{ zedDomainEntity | lcfirst }}Identifier]) : $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | resourceNameToModelName }}');"
               target:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | resourceNameToModelName }}Helper"
               withInterface:
                   value: false
 
@@ -102,7 +102,7 @@ postSpryks:
                 body:
                     value: Glue/Test/GlueTestHelper/BuildBackendApiUrlMethod.php.twig
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | resourceNameToModelName }}Helper"
                 withInterface:
                     value: false
                 visibility:
@@ -123,7 +123,7 @@ postSpryks:
                 body:
                     value: Glue/Test/GlueTestHelper/FormatUrlMethod.php.twig
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | resourceNameToModelName }}Helper"
                 withInterface:
                     value: false
                 visibility:

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestHelper.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestHelper.yml
@@ -51,7 +51,7 @@ arguments:
         description: "The response code e.g. 200"
 
     controller:
-        default: "{{ resource | normalizeResourceName }}ResourceController"
+        default: "{{ resource | normalizeResourceName | resourceNameToControllerName }}ResourceController"
 
     zedDomainEntity:
         inherit: true
@@ -64,7 +64,7 @@ postSpryks:
     - AddTestHelper:
         arguments:
             className:
-                value: "{{ resource | normalizeResourceName | ucfirst }}Helper"
+                value: "{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
         excludedSpryks:
             - EnableTestHelper
 
@@ -75,15 +75,15 @@ postSpryks:
               isBulk:
                   inherit: true
               method:
-                  value: "build{{ resource | normalizeResourceName | ucfirst }}Url"
+                  value: "build{{ resource | normalizeResourceName | resourceNameToModelName }}Url"
               input:
                   value: "?int ${{ zedDomainEntity | lcfirst }}Identifier = null"
               output:
                   value: string
               body:
-                  value: "return ${{ zedDomainEntity | lcfirst }}Identifier !== null ? $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | lcfirst }}/{id}', ['id' => ${{ zedDomainEntity | lcfirst }}Identifier]) : $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | lcfirst }}');"
+                  value: "return ${{ zedDomainEntity | lcfirst }}Identifier !== null ? $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | lcfirst }}/{id}', ['id' => ${{ zedDomainEntity | lcfirst }}Identifier]) : $this->build{{ applicationType | ucfirst }}ApiUrl('{{ resource | normalizeResourceName | resourceNameToModelName }}');"
               target:
-                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | ucfirst }}Helper"
+                  value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
               withInterface:
                   value: false
 
@@ -102,7 +102,7 @@ postSpryks:
                 body:
                     value: Glue/Test/GlueTestHelper/BuildBackendApiUrlMethod.php.twig
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | ucfirst }}Helper"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
                 withInterface:
                     value: false
                 visibility:
@@ -123,7 +123,7 @@ postSpryks:
                 body:
                     value: Glue/Test/GlueTestHelper/FormatUrlMethod.php.twig
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | ucfirst }}Helper"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\Helper\\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper"
                 withInterface:
                     value: false
                 visibility:

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestTester.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestTester.yml
@@ -14,7 +14,7 @@ arguments:
         default: false
 
     module:
-        value: "{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api"
+        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -45,7 +45,7 @@ arguments:
         value: Glue/Test/GlueTestTester/ApiTester.php.twig
 
     className:
-        value: "{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
 
     targetFilename:
         value: "{{ className }}.php"
@@ -70,7 +70,7 @@ postSpryks:
             body:
                 value: "$this->seeResponseJsonPathContains(['data' => ['type' => '{{ zedDomainEntity | lcfirst }}', 'id' => ${{ zedDomainEntity | lcfirst }}Id, 'attributes' => ['id{{ zedDomainEntity }}' => ${{ zedDomainEntity | lcfirst }}Id, 'uuid' => $uuid]]]);"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false
 
@@ -86,7 +86,7 @@ postSpryks:
                 body:
                     value: "return ['page' => ['offset' => 1, 'limit' => 1], 'sort' => '-id{{ zedDomainEntity }}'];"
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
                 withInterface:
                     value: false
     -   AddMethod:
@@ -103,7 +103,7 @@ postSpryks:
                         - "$this->seeResponseJsonPathContains(['data' => [['type' => '{{ zedDomainEntity | lcfirst }}']]]);"
                         - "$this->seeResponseMatchesJsonType(['data' => [['id' => 'integer:>0', 'attributes' => ['id{{ zedDomainEntity }}' => 'integer:>0', 'uuid' => 'string']]]]);"
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
                 withInterface:
                     value: false
 
@@ -121,7 +121,7 @@ postSpryks:
                     - "$this->seeResponseJsonPathContains(['data' => ['type' => '{{ zedDomainEntity | lcfirst }}']]);"
                     - "$this->seeResponseMatchesJsonType(['data' => ['id' => 'integer:>0', 'attributes' => ['id{{ zedDomainEntity }}' => 'integer:>0', 'uuid' => 'string']]]);"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false
 
@@ -141,6 +141,6 @@ postSpryks:
             body:
                 value: "return ['data' => ['type' => '{{ zedDomainEntity | lcfirst }}', 'id' => ${{ zedDomainEntity | lcfirst }}Id, 'attributes' => ['id{{ zedDomainEntity }}' => ${{ zedDomainEntity | lcfirst }}Id, 'uuid' => $uuid]]];"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false

--- a/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestTester.yml
+++ b/config/spryk/spryks/Spryker/Glue/Test/AddGlueTestTester.yml
@@ -14,7 +14,7 @@ arguments:
         default: false
 
     module:
-        value: "{{ resource | normalizeResourceName | resourceNameToModuleName }}{{ applicationType }}Api"
+        value: "{{ resource | resourceNameToModuleName }}{{ applicationType }}Api"
 
     organization:
         inherit: true
@@ -45,7 +45,7 @@ arguments:
         value: Glue/Test/GlueTestTester/ApiTester.php.twig
 
     className:
-        value: "{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+        value: "{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
 
     targetFilename:
         value: "{{ className }}.php"
@@ -70,7 +70,7 @@ postSpryks:
             body:
                 value: "$this->seeResponseJsonPathContains(['data' => ['type' => '{{ zedDomainEntity | lcfirst }}', 'id' => ${{ zedDomainEntity | lcfirst }}Id, 'attributes' => ['id{{ zedDomainEntity }}' => ${{ zedDomainEntity | lcfirst }}Id, 'uuid' => $uuid]]]);"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false
 
@@ -86,7 +86,7 @@ postSpryks:
                 body:
                     value: "return ['page' => ['offset' => 1, 'limit' => 1], 'sort' => '-id{{ zedDomainEntity }}'];"
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
                 withInterface:
                     value: false
     -   AddMethod:
@@ -103,7 +103,7 @@ postSpryks:
                         - "$this->seeResponseJsonPathContains(['data' => [['type' => '{{ zedDomainEntity | lcfirst }}']]]);"
                         - "$this->seeResponseMatchesJsonType(['data' => [['id' => 'integer:>0', 'attributes' => ['id{{ zedDomainEntity }}' => 'integer:>0', 'uuid' => 'string']]]]);"
                 target:
-                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+                    value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
                 withInterface:
                     value: false
 
@@ -121,7 +121,7 @@ postSpryks:
                     - "$this->seeResponseJsonPathContains(['data' => ['type' => '{{ zedDomainEntity | lcfirst }}']]);"
                     - "$this->seeResponseMatchesJsonType(['data' => ['id' => 'integer:>0', 'attributes' => ['id{{ zedDomainEntity }}' => 'integer:>0', 'uuid' => 'string']]]);"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false
 
@@ -141,6 +141,6 @@ postSpryks:
             body:
                 value: "return ['data' => ['type' => '{{ zedDomainEntity | lcfirst }}', 'id' => ${{ zedDomainEntity | lcfirst }}Id, 'attributes' => ['id{{ zedDomainEntity }}' => ${{ zedDomainEntity | lcfirst }}Id, 'uuid' => $uuid]]];"
             target:
-                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester"
+                value: "\\{{ organization }}Test\\{{ application }}\\{{ module }}\\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester"
             withInterface:
                 value: false

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/ApiCest.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/ApiCest.php.twig
@@ -12,8 +12,8 @@ use {{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{
  *
  * @group {{ organization }}Test
  * @group {{ application }}
- * @group {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api
- * @group {{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{{ suite }}Cest
+ * @group {{ resource | resourceNameToModelName }}{{ applicationType }}Api
+ * @group {{ resource | resourceNameToModelName }}{{ httpMethod | ucfirst }}{{ suite }}Cest
  */
 class {{ className }}
 {
@@ -24,11 +24,11 @@ class {{ className }}
     protected \{{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{{ fixtureClass }} $fixtures;
 
     /**
-     * @param \{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
+     * @param \{{ organization }}Test\{{ application }}\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
      *
      * @return void
      */
-    public function loadFixtures(\{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): void
+    public function loadFixtures(\{{ organization }}Test\{{ application }}\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I): void
     {
         /** @var \{{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{{ fixtureClass }} $fixtures */
         $fixtures = $I->loadFixtures({{ fixtureClass }}::class);

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/ApiCest.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/ApiCest.php.twig
@@ -12,8 +12,8 @@ use {{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{
  *
  * @group {{ organization }}Test
  * @group {{ application }}
- * @group {{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api
- * @group {{ resource | normalizeResourceName | ucfirst }}{{ httpMethod | ucfirst }}{{ suite }}Cest
+ * @group {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api
+ * @group {{ resource | normalizeResourceName | resourceNameToModelName }}{{ httpMethod | ucfirst }}{{ suite }}Cest
  */
 class {{ className }}
 {
@@ -24,11 +24,11 @@ class {{ className }}
     protected \{{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{{ fixtureClass }} $fixtures;
 
     /**
-     * @param \{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
+     * @param \{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
      *
      * @return void
      */
-    public function loadFixtures(\{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I): void
+    public function loadFixtures(\{{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): void
     {
         /** @var \{{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures\{{ fixtureClass }} $fixtures */
         $fixtures = $I->loadFixtures({{ fixtureClass }}::class);

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
@@ -1,6 +1,6 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
-$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendDelete($url, '');

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/DeleteCestMethod.php.twig
@@ -1,6 +1,6 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
-$url = $I->build{{ resource | normalizeResourceName | ucfirst }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendDelete($url, '');

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
@@ -1,7 +1,7 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
 $uuid = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getUuid();
-$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendGet($url);

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCestMethod.php.twig
@@ -1,7 +1,7 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
 $uuid = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getUuid();
-$url = $I->build{{ resource | normalizeResourceName | ucfirst }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendGet($url);

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
@@ -1,5 +1,5 @@
 // Arrange
-$url = $I->build{{ resource | normalizeResourceName | ucfirst }}Url();
+$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url();
 
 // Act
 $I->sendGet($url, $I->build{{ httpMethod | ucfirst }}Collection{{ zedDomainEntity }}RequestParameters());

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/GetCollectionCestMethod.php.twig
@@ -1,5 +1,5 @@
 // Arrange
-$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url();
+$url = $I->build{{ resource | resourceNameToModelName }}Url();
 
 // Act
 $I->sendGet($url, $I->build{{ httpMethod | ucfirst }}Collection{{ zedDomainEntity }}RequestParameters());

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
@@ -1,7 +1,7 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
 $newUuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
-$url = $I->build{{ resource | normalizeResourceName | ucfirst }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendPatch($url, $I->build{{ zedDomainEntity }}RequestData(${{ zedDomainEntity | lcfirst }}Id, $newUuid));

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/PatchCestMethod.php.twig
@@ -1,7 +1,7 @@
 // Arrange
 ${{ zedDomainEntity | lcfirst }}Id = $this->fixtures->get{{ zedDomainEntity }}Transfer()->getId{{ zedDomainEntity }}();
 $newUuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
-$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
+$url = $I->build{{ resource | resourceNameToModelName }}Url(${{ zedDomainEntity | lcfirst }}Id);
 
 // Act
 $I->sendPatch($url, $I->build{{ zedDomainEntity }}RequestData(${{ zedDomainEntity | lcfirst }}Id, $newUuid));

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
@@ -1,5 +1,5 @@
 // Arrange
-$url = $I->build{{ resource | normalizeResourceName | ucfirst }}Url();
+$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url();
 
 // Act
 $I->sendPost($url);

--- a/config/spryk/templates/Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestApiCest/PostCestMethod.php.twig
@@ -1,5 +1,5 @@
 // Arrange
-$url = $I->build{{ resource | normalizeResourceName | resourceNameToModelName }}Url();
+$url = $I->build{{ resource | resourceNameToModelName }}Url();
 
 // Act
 $I->sendPost($url);

--- a/config/spryk/templates/Glue/Test/GlueTestCodeceptionConfiguration.yml.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestCodeceptionConfiguration.yml.twig
@@ -1,9 +1,9 @@
 {{ suite }}:
-    class_name: {{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester
+    class_name: {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester
     modules:
         enabled:
             - Asserts
-            - \{{ organization }}Test\{{ application }}\{{ module }}\Helper\{{ resource | normalizeResourceName | ucfirst }}Helper
+            - \{{ organization }}Test\{{ application }}\{{ module }}\Helper\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper
             - \PyzTest\Shared\Testify\Helper\Environment
             -
                 \SprykerTest\Shared\Testify\Helper\LocatorHelper:

--- a/config/spryk/templates/Glue/Test/GlueTestCodeceptionConfiguration.yml.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestCodeceptionConfiguration.yml.twig
@@ -1,9 +1,9 @@
 {{ suite }}:
-    class_name: {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester
+    class_name: {{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester
     modules:
         enabled:
             - Asserts
-            - \{{ organization }}Test\{{ application }}\{{ module }}\Helper\{{ resource | normalizeResourceName | resourceNameToModelName }}Helper
+            - \{{ organization }}Test\{{ application }}\{{ module }}\Helper\{{ resource | resourceNameToModelName }}Helper
             - \PyzTest\Shared\Testify\Helper\Environment
             -
                 \SprykerTest\Shared\Testify\Helper\LocatorHelper:

--- a/config/spryk/templates/Glue/Test/GlueTestFixtures/TestFixtures.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestFixtures/TestFixtures.php.twig
@@ -3,7 +3,7 @@
 {{ include('Partials/license.twig') }}
 namespace {{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures;
 
-use {{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}Api\{{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester;
+use {{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester;
 use Generated\Shared\Transfer\{{ zedDomainEntity }}Transfer;
 use Ramsey\Uuid\Uuid;
 use SprykerTest\Shared\Testify\Fixtures\FixturesBuilderInterface;
@@ -28,11 +28,11 @@ class {{ className }} implements FixturesBuilderInterface, FixturesContainerInte
     protected ${{ zedDomainEntity | lcfirst }}Transfer;
 {% endif %}
     /**
-     * @param {{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
+     * @param {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I
      *
      * @return \SprykerTest\Shared\Testify\Fixtures\FixturesContainerInterface
      */
-    public function buildFixtures({{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I): FixturesContainerInterface
+    public function buildFixtures({{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): FixturesContainerInterface
     {
 {% if isBulk.value %}
         $this->{{ zedDomainEntity | lcfirst }}TransferOne = $this->build{{ zedDomainEntity }}TransferFixture($I);
@@ -46,11 +46,11 @@ class {{ className }} implements FixturesBuilderInterface, FixturesContainerInte
     }
 
     /**
-    * @param {{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I
+    * @param {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I
     *
     * @return \Generated\Shared\Transfer\{{ zedDomainEntity }}Transfer
     */
-    protected function build{{ zedDomainEntity }}TransferFixture({{ resource | normalizeResourceName | ucfirst }}{{ applicationType }}ApiTester $I): {{ zedDomainEntity }}Transfer
+    protected function build{{ zedDomainEntity }}TransferFixture({{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): {{ zedDomainEntity }}Transfer
     {
         $seed = ['uuid' => (Uuid::uuid4())->toString()];
         ${{ zedDomainEntity | lcfirst }}Transfer = $I->have{{ zedDomainEntity }}TransferPersisted($seed);

--- a/config/spryk/templates/Glue/Test/GlueTestFixtures/TestFixtures.php.twig
+++ b/config/spryk/templates/Glue/Test/GlueTestFixtures/TestFixtures.php.twig
@@ -3,7 +3,7 @@
 {{ include('Partials/license.twig') }}
 namespace {{ organization }}Test\{{ application }}\{{ module }}\{{ suite }}\Fixtures;
 
-use {{ organization }}Test\{{ application }}\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester;
+use {{ organization }}Test\{{ application }}\{{ resource | resourceNameToModelName }}{{ applicationType }}Api\{{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester;
 use Generated\Shared\Transfer\{{ zedDomainEntity }}Transfer;
 use Ramsey\Uuid\Uuid;
 use SprykerTest\Shared\Testify\Fixtures\FixturesBuilderInterface;
@@ -28,11 +28,11 @@ class {{ className }} implements FixturesBuilderInterface, FixturesContainerInte
     protected ${{ zedDomainEntity | lcfirst }}Transfer;
 {% endif %}
     /**
-     * @param {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I
+     * @param {{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I
      *
      * @return \SprykerTest\Shared\Testify\Fixtures\FixturesContainerInterface
      */
-    public function buildFixtures({{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): FixturesContainerInterface
+    public function buildFixtures({{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I): FixturesContainerInterface
     {
 {% if isBulk.value %}
         $this->{{ zedDomainEntity | lcfirst }}TransferOne = $this->build{{ zedDomainEntity }}TransferFixture($I);
@@ -46,11 +46,11 @@ class {{ className }} implements FixturesBuilderInterface, FixturesContainerInte
     }
 
     /**
-    * @param {{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I
+    * @param {{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I
     *
     * @return \Generated\Shared\Transfer\{{ zedDomainEntity }}Transfer
     */
-    protected function build{{ zedDomainEntity }}TransferFixture({{ resource | normalizeResourceName | resourceNameToModelName }}{{ applicationType }}ApiTester $I): {{ zedDomainEntity }}Transfer
+    protected function build{{ zedDomainEntity }}TransferFixture({{ resource | resourceNameToModelName }}{{ applicationType }}ApiTester $I): {{ zedDomainEntity }}Transfer
     {
         $seed = ['uuid' => (Uuid::uuid4())->toString()];
         ${{ zedDomainEntity | lcfirst }}Transfer = $I->have{{ zedDomainEntity }}TransferPersisted($seed);

--- a/src/Spryk/Model/Spryk/Filter/NormalizeResourceNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/NormalizeResourceNameFilter.php
@@ -16,6 +16,11 @@ use Laminas\Filter\Word\DashToCamelCase;
  *
  * Example:
  * $this->filter('/foo-bars') === `FooBars';
+ *
+ * @deprecated Use one of the ResourceNameTo* filters instead
+ * @see \SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModuleNameFilter
+ * @see \SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModelNameFilter
+ * @see \SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToControllerNameFilter
  */
 class NormalizeResourceNameFilter implements FilterInterface
 {

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
@@ -7,6 +7,8 @@
 
 namespace SprykerSdk\Spryk\Model\Spryk\Filter;
 
+use Laminas\Filter\Word\DashToCamelCase;
+
 /**
  * Converts a resource name to the appropriate controller name
  *
@@ -48,6 +50,8 @@ class ResourceNameToControllerNameFilter implements FilterInterface
             $name = $parts[1];
         }
 
-        return ucfirst($name);
+        $filter = new DashToCamelCase();
+
+        return $filter->filter($name);
     }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
@@ -10,9 +10,13 @@ namespace SprykerSdk\Spryk\Model\Spryk\Filter;
 /**
  * Converts a resource name to the appropriate controller name
  *
+ * The scheme follows the same convention as used in Spryker's Zed controllers and actions
+ *
+ * @see https://docs.spryker.com/docs/scos/dev/back-end-development/zed/communication-layer/communication-layer.html#input-parameters
+ *
  * Example:
- * $this->filter('/foo/bar/baz') == 'Bar'
  * $this->filter('/foo') == 'Index'
+ * $this->filter('/foo/bar/baz') == 'Bar'
  */
 class ResourceNameToControllerNameFilter implements FilterInterface
 {

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\Spryk\Model\Spryk\Filter;
+
+/**
+ * Converts a resource name to the appropriate controller name
+ *
+ * Example:
+ * $this->filter('/foo/bar/baz') == 'Bar'
+ * $this->filter('/foo') == 'Index'
+ */
+class ResourceNameToControllerNameFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected const FILTER_NAME = 'resourceNameToControllerName';
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::FILTER_NAME;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    public function filter(string $value): string
+    {
+        $normalized = trim($value, '/');
+        $parts = explode('/', $normalized);
+
+        $name = 'Index';
+        if (!empty($parts[1])) {
+            $name = $parts[1];
+        }
+
+        return ucfirst($name);
+    }
+}

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
@@ -40,9 +40,9 @@ class ResourceNameToControllerNameFilter implements FilterInterface
      */
     public function filter(string $value): string
     {
-        $normalized = trim($value, '/');
-        $parts = explode('/', $normalized);
-
+        $parts = array_filter(explode('/', $value));
+        # resets indexes used further down
+        $parts = array_values($parts);
         $name = 'Index';
         if (!empty($parts[1])) {
             $name = $parts[1];

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilter.php
@@ -28,6 +28,19 @@ class ResourceNameToControllerNameFilter implements FilterInterface
     protected const FILTER_NAME = 'resourceNameToControllerName';
 
     /**
+     * @var \Laminas\Filter\Word\DashToCamelCase
+     */
+    private DashToCamelCase $dashToCamelCase;
+
+    /**
+     * @param \Laminas\Filter\Word\DashToCamelCase $dashToCamelCase
+     */
+    public function __construct(DashToCamelCase $dashToCamelCase)
+    {
+        $this->dashToCamelCase = $dashToCamelCase;
+    }
+
+    /**
      * @return string
      */
     public function getName(): string
@@ -50,8 +63,6 @@ class ResourceNameToControllerNameFilter implements FilterInterface
             $name = $parts[1];
         }
 
-        $filter = new DashToCamelCase();
-
-        return $filter->filter($name);
+        return $this->dashToCamelCase->filter($name);
     }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
@@ -11,8 +11,9 @@ namespace SprykerSdk\Spryk\Model\Spryk\Filter;
  * Converts a resource name to model name
  *
  * Examples:
- * $this->filter('/foo') == 'Foo';
- * $this->filter('/foo/*') == 'Foo';
+ * $this->filter('/foo') === 'Foo';
+ * $this->filter('/foo/*') === 'Foo';
+ * $this->filter('/foo-bar/*') === 'FooBar';
  */
 class ResourceNameToModelNameFilter extends ResourceNameToModuleNameFilter
 {

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
@@ -11,9 +11,8 @@ namespace SprykerSdk\Spryk\Model\Spryk\Filter;
  * Converts a resource name to model name
  *
  * Examples:
- * $this->filter('/customer') == 'Customer';
- * $this->filter('/customer/account') == 'Account';
- * $this->filter('/customer/account/history') == 'History';
+ * $this->filter('/foo') == 'Foo';
+ * $this->filter('/foo/*') == 'Foo';
  */
 class ResourceNameToModelNameFilter implements FilterInterface
 {
@@ -43,6 +42,6 @@ class ResourceNameToModelNameFilter implements FilterInterface
             $parts = [''];
         }
 
-        return ucfirst(end($parts));
+        return ucfirst(current($parts));
     }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\Spryk\Model\Spryk\Filter;
+
+/**
+ * Converts a resource name to model name
+ *
+ * Examples:
+ * $this->filter('/customer') == 'Customer';
+ * $this->filter('/customer/account') == 'Account';
+ * $this->filter('/customer/account/history') == 'History';
+ */
+class ResourceNameToModelNameFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected const FILTER_NAME = 'resourceNameToModelName';
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::FILTER_NAME;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    public function filter(string $value): string
+    {
+        $parts = array_filter(explode('/', $value));
+
+        if (count($parts) === 0) {
+            $parts = [''];
+        }
+
+        return ucfirst(end($parts));
+    }
+}

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilter.php
@@ -14,34 +14,10 @@ namespace SprykerSdk\Spryk\Model\Spryk\Filter;
  * $this->filter('/foo') == 'Foo';
  * $this->filter('/foo/*') == 'Foo';
  */
-class ResourceNameToModelNameFilter implements FilterInterface
+class ResourceNameToModelNameFilter extends ResourceNameToModuleNameFilter
 {
     /**
      * @var string
      */
     protected const FILTER_NAME = 'resourceNameToModelName';
-
-    /**
-     * @return string
-     */
-    public function getName(): string
-    {
-        return static::FILTER_NAME;
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return string
-     */
-    public function filter(string $value): string
-    {
-        $parts = array_filter(explode('/', $value));
-
-        if (count($parts) === 0) {
-            $parts = [''];
-        }
-
-        return ucfirst(current($parts));
-    }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdk\Spryk\Model\Spryk\Filter;
+
+/**
+ * Converts a resource name to the corresponding module name
+ *
+ * Examples:
+ * $this->filter('/customer') === 'Customer';
+ * $this->filter('/customer/account') === 'Customer';
+ */
+class ResourceNameToModuleNameFilter implements FilterInterface
+{
+    /**
+     * @var string
+     */
+    protected const FILTER_NAME = 'resourceNameToModuleName';
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return static::FILTER_NAME;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string
+     */
+    public function filter(string $value): string
+    {
+        $parts = array_filter(explode('/', $value));
+
+        return ucfirst(current($parts));
+    }
+}

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
@@ -11,8 +11,8 @@ namespace SprykerSdk\Spryk\Model\Spryk\Filter;
  * Converts a resource name to the corresponding module name
  *
  * Examples:
- * $this->filter('/customer') === 'Customer';
- * $this->filter('/customer/account') === 'Customer';
+ * $this->filter('/foo') === 'Foo';
+ * $this->filter('/foo/*') === 'Foo';
  */
 class ResourceNameToModuleNameFilter implements FilterInterface
 {

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
@@ -38,6 +38,10 @@ class ResourceNameToModuleNameFilter implements FilterInterface
     {
         $parts = array_filter(explode('/', $value));
 
+        if (count($parts) === 0) {
+            $parts = [''];
+        }
+
         return ucfirst(current($parts));
     }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
@@ -7,12 +7,15 @@
 
 namespace SprykerSdk\Spryk\Model\Spryk\Filter;
 
+use Laminas\Filter\Word\DashToCamelCase;
+
 /**
  * Converts a resource name to the corresponding module name
  *
  * Examples:
  * $this->filter('/foo') === 'Foo';
  * $this->filter('/foo/*') === 'Foo';
+ * $this->filter('/foo-bar/*') === 'FooBar';
  */
 class ResourceNameToModuleNameFilter implements FilterInterface
 {
@@ -42,6 +45,8 @@ class ResourceNameToModuleNameFilter implements FilterInterface
             $parts = [''];
         }
 
-        return ucfirst(current($parts));
+        $filter = new DashToCamelCase();
+
+        return $filter->filter(current($parts));
     }
 }

--- a/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
+++ b/src/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilter.php
@@ -25,6 +25,19 @@ class ResourceNameToModuleNameFilter implements FilterInterface
     protected const FILTER_NAME = 'resourceNameToModuleName';
 
     /**
+     * @var \Laminas\Filter\Word\DashToCamelCase
+     */
+    private DashToCamelCase $dashToCamelCase;
+
+    /**
+     * @param \Laminas\Filter\Word\DashToCamelCase $dashToCamelCase
+     */
+    public function __construct(DashToCamelCase $dashToCamelCase)
+    {
+        $this->dashToCamelCase = $dashToCamelCase;
+    }
+
+    /**
      * @return string
      */
     public function getName(): string
@@ -45,8 +58,6 @@ class ResourceNameToModuleNameFilter implements FilterInterface
             $parts = [''];
         }
 
-        $filter = new DashToCamelCase();
-
-        return $filter->filter(current($parts));
+        return $this->dashToCamelCase->filter(current($parts));
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
+++ b/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
@@ -86,7 +86,7 @@ class AddGlueResourceMethodResponseTest extends Unit
         $this->tester->run($this, $commandOptions);
 
         // Controller and method
-        $this->tester->assertClassOrInterfaceHasMethod(GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER, $expectedControllerMethodName);
+        $this->tester->assertClassOrInterfaceHasMethod(GlueBackendApiClassNames::GLUE_BACKEND_API_INDEX_CONTROLLER, $expectedControllerMethodName);
 
         // Controller test class
         $this->tester->assertClassOrInterfaceExists($expectedTestController);
@@ -270,10 +270,7 @@ class AddGlueResourceMethodResponseTest extends Unit
 
         $this->tester->run($this, $commandOptions);
 
-        $indexController = GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER;
-        $bazController = str_replace('\\Controller\\Index', '\\Controller\\' . $expectedControllerName, $indexController);
-
-        $this->tester->assertClassExists($bazController);
+        $this->tester->assertClassExists($expectedControllerName);
     }
 
     /**
@@ -282,9 +279,8 @@ class AddGlueResourceMethodResponseTest extends Unit
     public function resourcePathControllerProvider(): array
     {
         return [
-            ['/foo-bars', 'Index'],
-            ['/foo-bars/foo', 'Foo'],
-            ['/foo-bars/baz', 'Baz'],
+            ['/foo-bars', GlueBackendApiClassNames::GLUE_BACKEND_API_INDEX_CONTROLLER],
+            ['/foo-bars/foo-bar', GlueBackendApiClassNames::GLUE_BACKEND_API_FOO_BAR_CONTROLLER],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
+++ b/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
@@ -38,6 +38,7 @@ class AddGlueResourceMethodResponseTest extends Unit
      * @param string|null $dataModule
      * @param string|null $zedDomainEntity
      * @param string|null $resourceDataObject
+     * @param string|null $resource
      *
      * @return void
      */
@@ -246,5 +247,44 @@ class AddGlueResourceMethodResponseTest extends Unit
     protected function getExpectedTestControllerMethodName(string $httpMethod, int $httpResponseCode, ?bool $isBulk): string
     {
         return sprintf('requestFooBar%s%sReturnsHttpResponseCode%s', ucfirst($httpMethod), ($isBulk) ? 'Collection' : '', $httpResponseCode);
+    }
+
+    /**
+     * @dataProvider resourcePathControllerProvider
+     *
+     * @param string $resource
+     * @param string $expectedControllerName
+     *
+     * @return void
+     */
+    public function testAddsControllerBasedOnResourcePath(string $resource, string $expectedControllerName): void
+    {
+        $httpMethod = 'get';
+        $httpResponseCode = 200;
+
+        $commandOptions = [
+            '--resource' => $resource,
+            '--httpMethod' => $httpMethod,
+            '--httpResponseCode' => $httpResponseCode,
+        ];
+
+        $this->tester->run($this, $commandOptions);
+
+        $indexController = GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER;
+        $bazController = str_replace('\\Controller\\Index', '\\Controller\\' . $expectedControllerName, $indexController);
+
+        $this->tester->assertClassExists($bazController);
+    }
+
+    /**
+     * @return \array<array<string>>
+     */
+    public function resourcePathControllerProvider(): array
+    {
+        return [
+            ['/foo-bars', 'Index'],
+            ['/foo-bars/foo', 'Foo'],
+            ['/foo-bars/baz', 'Baz'],
+        ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
+++ b/tests/SprykerSdkTest/Spryk/Integration/Glue/AddGlueResourceMethodResponseTest.php
@@ -48,13 +48,14 @@ class AddGlueResourceMethodResponseTest extends Unit
         ?string $module = null,
         ?string $dataModule = null,
         ?string $zedDomainEntity = null,
-        ?string $resourceDataObject = null
+        ?string $resourceDataObject = null,
+        ?string $resource = null
     ): void {
         $commandOptions = [
             // TODO We also need to add tests for project level
 //            '--mode' => 'project',
 //            '--organization' => 'Pyz',
-            '--resource' => '/foo-bars',
+            '--resource' => $resource ?? '/foo-bars',
             '--httpMethod' => $httpMethod,
             '--httpResponseCode' => $httpResponseCode,
         ];
@@ -153,6 +154,7 @@ class AddGlueResourceMethodResponseTest extends Unit
             ['patch', 200],
             ['delete', 200],
             ['delete', 200, true],
+            ['get', 200, true, null, null, null, null, '/foo-bars/index'],
         ];
     }
 

--- a/tests/SprykerSdkTest/Spryk/Integration/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetTest.php
+++ b/tests/SprykerSdkTest/Spryk/Integration/Glue/BackendApi/Controller/AddGlueBackendApiControllerMethodGetTest.php
@@ -37,8 +37,8 @@ class AddGlueBackendApiControllerMethodGetTest extends Unit
             '--zedDomainEntity' => 'ZipZap',
         ]);
 
-        $this->tester->assertClassOrInterfaceExists(GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER);
+        $this->tester->assertClassOrInterfaceExists(GlueBackendApiClassNames::GLUE_BACKEND_API_INDEX_CONTROLLER);
         $this->tester->assertClassOrInterfaceExists(GlueBackendApiClassNames::GLUE_BACKEND_API_GET_CONTROLLER_TEST);
-        $this->tester->assertClassOrInterfaceHasMethod(GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER, 'getAction');
+        $this->tester->assertClassOrInterfaceHasMethod(GlueBackendApiClassNames::GLUE_BACKEND_API_INDEX_CONTROLLER, 'getAction');
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Integration/Glue/BackendApi/Controller/AddGlueBackendApiControllerTest.php
+++ b/tests/SprykerSdkTest/Spryk/Integration/Glue/BackendApi/Controller/AddGlueBackendApiControllerTest.php
@@ -37,6 +37,6 @@ class AddGlueBackendApiControllerTest extends Unit
             '--resource' => '/foo-bars',
         ]);
 
-        $this->tester->assertClassOrInterfaceExists(GlueBackendApiClassNames::GLUE_BACKEND_API_CONTROLLER);
+        $this->tester->assertClassOrInterfaceExists(GlueBackendApiClassNames::GLUE_BACKEND_API_INDEX_CONTROLLER);
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
+
+use Codeception\Test\Unit;
+use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToControllerNameFilter;
+
+class ResourceNameToControllerNameFilterTest extends Unit
+{
+    /**
+     * @dataProvider resourceNameProvider
+     *
+     * @param string $resource
+     * @param string $expectedResult
+     *
+     * @return void
+     */
+    public function testResourceNameConversion(string $resource, string $expectedResult): void
+    {
+        $filter = new ResourceNameToControllerNameFilter();
+        $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
+    }
+
+    /**
+     * @return array<array<\string>>
+     */
+    public function resourceNameProvider(): array
+    {
+        return [
+            ['', 'Index'],
+            ['/', 'Index'],
+            ['foo', 'Index'],
+            ['/foo', 'Index'],
+            ['foo/bar', 'Bar'],
+            ['/foo/bar', 'Bar'],
+            ['foo/bar/baz', 'Bar'],
+            ['/foo/bar/baz', 'Bar'],
+            ['foo//bar', 'Index'],
+            ['/foo//bar', 'Index'],
+        ];
+    }
+}

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
@@ -9,9 +9,12 @@ namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
 
 use Codeception\Test\Unit;
 use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToControllerNameFilter;
+use SprykerSdkTest\SprykTester;
 
 class ResourceNameToControllerNameFilterTest extends Unit
 {
+    protected SprykTester $tester;
+
     /**
      * @dataProvider resourceNameProvider
      *
@@ -22,7 +25,7 @@ class ResourceNameToControllerNameFilterTest extends Unit
      */
     public function testResourceNameConversion(string $resource, string $expectedResult): void
     {
-        $filter = new ResourceNameToControllerNameFilter();
+        $filter = $this->tester->getFilter(ResourceNameToControllerNameFilter::class);
         $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
     }
 
@@ -42,6 +45,8 @@ class ResourceNameToControllerNameFilterTest extends Unit
             ['/foo/bar/baz', 'Bar'],
             ['foo//bar', 'Bar'],
             ['/foo//bar', 'Bar'],
+            ['/foo/foo-bars', 'FooBars'],
+            ['/foo//foo-bar-baz/fuz', 'FooBarBaz'],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToControllerNameFilterTest.php
@@ -40,8 +40,8 @@ class ResourceNameToControllerNameFilterTest extends Unit
             ['/foo/bar', 'Bar'],
             ['foo/bar/baz', 'Bar'],
             ['/foo/bar/baz', 'Bar'],
-            ['foo//bar', 'Index'],
-            ['/foo//bar', 'Index'],
+            ['foo//bar', 'Bar'],
+            ['/foo//bar', 'Bar'],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
@@ -9,9 +9,12 @@ namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
 
 use Codeception\Test\Unit;
 use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModelNameFilter;
+use SprykerSdkTest\SprykTester;
 
 class ResourceNameToModelNameFilterTest extends Unit
 {
+    protected SprykTester $tester;
+
     /**
      * @dataProvider resourceNameProvider
      *
@@ -22,7 +25,7 @@ class ResourceNameToModelNameFilterTest extends Unit
      */
     public function testResourceNameConversion(string $resource, string $expectedResult): void
     {
-        $filter = new ResourceNameToModelNameFilter();
+        $filter = $this->tester->getFilter(ResourceNameToModelNameFilter::class);
         $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
     }
 
@@ -38,6 +41,7 @@ class ResourceNameToModelNameFilterTest extends Unit
             ['/foo/bar', 'Foo'],
             ['/foo/bar/baz', 'Foo'],
             ['/fuz/baz', 'Fuz'],
+            ['/foo-bar/fuz/baz', 'FooBar'],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
+
+use Codeception\Test\Unit;
+use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModelNameFilter;
+
+class ResourceNameToModelNameFilterTest extends Unit
+{
+    /**
+     * @dataProvider resourceNameProvider
+     *
+     * @param string $resource
+     * @param string $expectedResult
+     *
+     * @return void
+     */
+    public function testResourceNameConversion(string $resource, string $expectedResult): void
+    {
+        $filter = new ResourceNameToModelNameFilter();
+        $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
+    }
+
+    /**
+     * @return array<array<\string>>
+     */
+    public function resourceNameProvider(): array
+    {
+        return [
+            ['', ''],
+            ['customer', 'Customer'],
+            ['/customer', 'Customer'],
+            ['/customer/account', 'Account'],
+            ['/customer/account/history', 'History'],
+        ];
+    }
+}

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModelNameFilterTest.php
@@ -33,10 +33,11 @@ class ResourceNameToModelNameFilterTest extends Unit
     {
         return [
             ['', ''],
-            ['customer', 'Customer'],
-            ['/customer', 'Customer'],
-            ['/customer/account', 'Account'],
-            ['/customer/account/history', 'History'],
+            ['foo', 'Foo'],
+            ['/foo', 'Foo'],
+            ['/foo/bar', 'Foo'],
+            ['/foo/bar/baz', 'Foo'],
+            ['/fuz/baz', 'Fuz'],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilterTest.php
@@ -9,9 +9,12 @@ namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
 
 use Codeception\Test\Unit;
 use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModuleNameFilter;
+use SprykerSdkTest\SprykTester;
 
 class ResourceNameToModuleNameFilterTest extends Unit
 {
+    protected SprykTester $tester;
+
     /**
      * @dataProvider resourceNameProvider
      *
@@ -22,7 +25,7 @@ class ResourceNameToModuleNameFilterTest extends Unit
      */
     public function testResourceNameConversion(string $resource, string $expectedResult): void
     {
-        $filter = new ResourceNameToModuleNameFilter();
+        $filter = $this->tester->getFilter(ResourceNameToModuleNameFilter::class);
         $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
     }
 
@@ -33,10 +36,10 @@ class ResourceNameToModuleNameFilterTest extends Unit
     {
         return [
             ['', ''],
-            ['customer', 'Customer'],
-            ['/customer', 'Customer'],
-            ['/customer/account', 'Customer'],
-            ['//customer/account', 'Customer'],
+            ['foo', 'Foo'],
+            ['/foo/bar', 'Foo'],
+            ['/foo-bar/baz', 'FooBar'],
+            ['//foo-bar/baz', 'FooBar'],
         ];
     }
 }

--- a/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilterTest.php
+++ b/tests/SprykerSdkTest/Spryk/Model/Spryk/Filter/ResourceNameToModuleNameFilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace SprykerSdkTest\Spryk\Model\Spryk\Filter;
+
+use Codeception\Test\Unit;
+use SprykerSdk\Spryk\Model\Spryk\Filter\ResourceNameToModuleNameFilter;
+
+class ResourceNameToModuleNameFilterTest extends Unit
+{
+    /**
+     * @dataProvider resourceNameProvider
+     *
+     * @param string $resource
+     * @param string $expectedResult
+     *
+     * @return void
+     */
+    public function testResourceNameConversion(string $resource, string $expectedResult): void
+    {
+        $filter = new ResourceNameToModuleNameFilter();
+        $this->assertSame($expectedResult, $filter->filter($resource), 'Input: ' . $resource);
+    }
+
+    /**
+     * @return array<array<\string>>
+     */
+    public function resourceNameProvider(): array
+    {
+        return [
+            ['', ''],
+            ['customer', 'Customer'],
+            ['/customer', 'Customer'],
+            ['/customer/account', 'Customer'],
+            ['//customer/account', 'Customer'],
+        ];
+    }
+}

--- a/tests/_support/Module/GlueBackendApiClassNames.php
+++ b/tests/_support/Module/GlueBackendApiClassNames.php
@@ -57,7 +57,12 @@ interface GlueBackendApiClassNames
     /**
      * @var string
      */
-    public const GLUE_BACKEND_API_CONTROLLER = 'Spryker\Glue\FooBarsBackendApi\Controller\IndexResourceController';
+    public const GLUE_BACKEND_API_INDEX_CONTROLLER = 'Spryker\Glue\FooBarsBackendApi\Controller\IndexResourceController';
+
+    /**
+     * @var string
+     */
+    public const GLUE_BACKEND_API_FOO_BAR_CONTROLLER = 'Spryker\Glue\FooBarsBackendApi\Controller\FooBarResourceController';
 
     /**
      * @var string

--- a/tests/_support/Module/GlueBackendApiClassNames.php
+++ b/tests/_support/Module/GlueBackendApiClassNames.php
@@ -57,7 +57,7 @@ interface GlueBackendApiClassNames
     /**
      * @var string
      */
-    public const GLUE_BACKEND_API_CONTROLLER = 'Spryker\Glue\FooBarsBackendApi\Controller\FooBarsResourceController';
+    public const GLUE_BACKEND_API_CONTROLLER = 'Spryker\Glue\FooBarsBackendApi\Controller\IndexResourceController';
 
     /**
      * @var string

--- a/tests/_support/Module/SprykHelper.php
+++ b/tests/_support/Module/SprykHelper.php
@@ -19,6 +19,7 @@ use SprykerSdk\Spryk\Model\Spryk\Builder\Dumper\FileDumperInterface;
 use SprykerSdk\Spryk\Model\Spryk\Builder\Resolver\FileResolverInterface;
 use SprykerSdk\Spryk\Model\Spryk\Executor\ConditionMatcher\ConditionMatcher;
 use SprykerSdk\Spryk\Model\Spryk\Executor\ConditionMatcher\ConditionMatcherInterface;
+use SprykerSdk\Spryk\Model\Spryk\Filter\FilterInterface;
 use SprykerSdk\Spryk\Model\Spryk\Filter\HttpResponseCodeToConstantNameFilter;
 use SprykerSdk\Spryk\Model\Spryk\NodeFinder\NodeFinderInterface;
 use SprykerSdk\Spryk\SprykConfig;
@@ -296,6 +297,16 @@ class SprykHelper extends Module
     public function getClass(string $classOrInterfaceName): object
     {
         return $this->getContainer()->get($classOrInterfaceName);
+    }
+
+    /**
+     * @param string $filterClassName
+     *
+     * @return \SprykerSdk\Spryk\Model\Spryk\Filter\FilterInterface
+     */
+    public function getFilter(string $filterClassName): FilterInterface
+    {
+        return $this->getContainer()->get($filterClassName);
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @k4emic

- Ticket: https://spryker.atlassian.net/browse/APPS-4625

- Docs PR: N/A(?)

- Release Group: N/A

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykSrc              | minor (currently 0.0.x)  |                       |

-----------------------------------------

#### Module SprykSrc

##### Change log

Allow resources to contain slashes (e.g. `/foo/bar`) in glue spryks