### PR TITLE
APPS-4387: Added a list of arguments for each Spryk in the dump command

### DIFF
--- a/src/Spryk/Console/SprykDumpConsole.php
+++ b/src/Spryk/Console/SprykDumpConsole.php
@@ -117,13 +117,10 @@ class SprykDumpConsole extends AbstractSprykConsole
     protected function dumpSpryk(OutputInterface $output, string $sprykName): void
     {
         $sprykDefinition = $this->getFacade()->getSprykDefinition($sprykName);
-        $options = $this->formatOptions($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]);
-        $description = $this->formatSprykDescription($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_DESCRIPTION]);
+        $sprykArguments = $this->formatSingleSprykArguments($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]);
+        $sprykDescription = $this->formatSingleSprykDescription($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_DESCRIPTION]);
 
-        $this->printTable($output, ['Description:'], [[$description]]);
-
-        $this->printTitleBlock($output, sprintf('List of all "%s" options:', $sprykName));
-        $this->printTable($output, ['Option'], $options);
+        $this->printTable($output, [$sprykName, $sprykDescription], $sprykArguments);
 
         $optionalSpryks = $this->getFormattedOptionalSpryks($sprykDefinition);
         if ($optionalSpryks !== []) {
@@ -189,19 +186,22 @@ class SprykDumpConsole extends AbstractSprykConsole
     }
 
     /**
-     * @param array $sprykDefinitions
+     * @param array $sprykDefinition
      *
      * @return array
      */
-    protected function formatOptions(array $sprykDefinitions): array
+    protected function formatSingleSprykArguments(array $sprykDefinition): array
     {
         $formatted = ['mode' => ['mode']];
-        foreach ($sprykDefinitions as $option => $optionDefinition) {
-            if (isset($optionDefinition[SprykConfig::NAME_ARGUMENT_KEY_VALUE])) {
+        foreach ($sprykDefinition as $argument => $argumentDefinition) {
+            if (isset($argumentDefinition[SprykConfig::NAME_ARGUMENT_KEY_VALUE])) {
                 continue;
             }
 
-            $formatted[$option] = [$option];
+            $formatted[$argument] = [
+                $argument,
+                $argumentDefinition[SprykConfig::NAME_ARGUMENT_KEY_DESCRIPTION] ?? '',
+            ];
         }
         sort($formatted);
 
@@ -213,7 +213,7 @@ class SprykDumpConsole extends AbstractSprykConsole
      *
      * @return string
      */
-    protected function formatSprykDescription(string $sprykDescription): string
+    protected function formatSingleSprykDescription(string $sprykDescription): string
     {
         return trim($sprykDescription);
     }

--- a/src/Spryk/Console/SprykDumpConsole.php
+++ b/src/Spryk/Console/SprykDumpConsole.php
@@ -71,7 +71,7 @@ class SprykDumpConsole extends AbstractSprykConsole
 
         $sprykName = current((array)$input->getArgument(static::ARGUMENT_SPRYK));
         if ($sprykName !== false) {
-            $this->dumpSprykOptions($output, $sprykName);
+            $this->dumpSpryk($output, $sprykName);
 
             return static::CODE_SUCCESS;
         }
@@ -114,12 +114,16 @@ class SprykDumpConsole extends AbstractSprykConsole
      *
      * @return void
      */
-    protected function dumpSprykOptions(OutputInterface $output, string $sprykName): void
+    protected function dumpSpryk(OutputInterface $output, string $sprykName): void
     {
         $sprykDefinition = $this->getFacade()->getSprykDefinition($sprykName);
-        $tableRows = $this->formatOptions($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]);
+        $options = $this->formatOptions($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]);
+        $description = $this->formatSprykDescription($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_DESCRIPTION]);
+
+        $this->printTable($output, ['Description:'], [[$description]]);
+
         $this->printTitleBlock($output, sprintf('List of all "%s" options:', $sprykName));
-        $this->printTable($output, ['Option'], $tableRows);
+        $this->printTable($output, ['Option'], $options);
 
         $optionalSpryks = $this->getFormattedOptionalSpryks($sprykDefinition);
         if ($optionalSpryks !== []) {
@@ -205,13 +209,23 @@ class SprykDumpConsole extends AbstractSprykConsole
     }
 
     /**
+     * @param string $sprykDescription
+     *
+     * @return string
+     */
+    protected function formatSprykDescription(string $sprykDescription): string
+    {
+        return trim($sprykDescription);
+    }
+
+    /**
      * @param array $sprykDefinition
      *
      * @return string
      */
     protected function formatArguments(array $sprykDefinition): string
     {
-        return implode(', ', array_keys($sprykDefinition['arguments']));
+        return implode(', ', array_keys($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]));
     }
 
     /**

--- a/src/Spryk/Console/SprykDumpConsole.php
+++ b/src/Spryk/Console/SprykDumpConsole.php
@@ -105,7 +105,7 @@ class SprykDumpConsole extends AbstractSprykConsole
         $sprykDefinitions = $this->formatSpryks($sprykDefinitions);
 
         $output->writeln('List of Spryk definitions:');
-        $this->printTable($output, ['Spryk name', 'Description'], $sprykDefinitions);
+        $this->printTable($output, ['Spryk name', 'Description', 'Arguments'], $sprykDefinitions);
     }
 
     /**
@@ -173,7 +173,11 @@ class SprykDumpConsole extends AbstractSprykConsole
             if (!isset($sprykDefinition['description'])) {
                 throw new Exception(sprintf('The Spryk "%s" doesn\'t have a description.', $sprykName));
             }
-            $formatted[$sprykName] = [$sprykName, $sprykDefinition['description']];
+            $formatted[$sprykName] = [
+                $sprykName,
+                $sprykDefinition['description'],
+                $this->formatArguments($sprykDefinition),
+            ];
         }
         sort($formatted);
 
@@ -198,6 +202,16 @@ class SprykDumpConsole extends AbstractSprykConsole
         sort($formatted);
 
         return $formatted;
+    }
+
+    /**
+     * @param array $sprykDefinition
+     *
+     * @return string
+     */
+    protected function formatArguments(array $sprykDefinition): string
+    {
+        return implode(', ', array_keys($sprykDefinition['arguments']));
     }
 
     /**

--- a/src/Spryk/Console/SprykDumpConsole.php
+++ b/src/Spryk/Console/SprykDumpConsole.php
@@ -120,6 +120,8 @@ class SprykDumpConsole extends AbstractSprykConsole
         $sprykArguments = $this->formatSingleSprykArguments($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_ARGUMENTS]);
         $sprykDescription = $this->formatSingleSprykDescription($sprykDefinition[SprykConfig::SPRYK_DEFINITION_KEY_DESCRIPTION]);
 
+        $this->printTitleBlock($output, sprintf('Description of the "%s" Spryk:', $sprykName));
+
         $this->printTable($output, [$sprykName, $sprykDescription], $sprykArguments);
 
         $optionalSpryks = $this->getFormattedOptionalSpryks($sprykDefinition);

--- a/src/Spryk/SprykConfig.php
+++ b/src/Spryk/SprykConfig.php
@@ -70,6 +70,11 @@ class SprykConfig
     /**
      * @var string
      */
+    public const NAME_ARGUMENT_KEY_DESCRIPTION = 'description';
+
+    /**
+     * @var string
+     */
     public const NAME_ARGUMENT_KEY_VALUES = 'values';
 
     /**

--- a/src/Spryk/SprykConfig.php
+++ b/src/Spryk/SprykConfig.php
@@ -25,6 +25,11 @@ class SprykConfig
     /**
      * @var string
      */
+    public const SPRYK_DEFINITION_KEY_DESCRIPTION = 'description';
+
+    /**
+     * @var string
+     */
     public const NAME_DEVELOPMENT_LAYER_CORE = 'core';
 
     /**

--- a/tests/SprykerSdkTest/Spryk/Console/SprykDumpTest.php
+++ b/tests/SprykerSdkTest/Spryk/Console/SprykDumpTest.php
@@ -61,7 +61,7 @@ class SprykDumpTest extends Unit
         $tester->execute($arguments);
 
         $output = $tester->getDisplay();
-        $this->assertRegExp('/List of all "AddModule" options/', $output);
+        $this->assertRegExp('/Description of the "AddModule" Spryk/', $output);
     }
 
     /**


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/APPS-4387

A description has been already provided in the output of the command. 
Example of use:
![image](https://user-images.githubusercontent.com/95215341/178746457-4089ec7a-7454-4e2b-a954-1c03bc087467.png)
