### PR TITLE
FRW-112 fixed redeclared const issue

### DIFF
--- a/bin/environment.php
+++ b/bin/environment.php
@@ -57,5 +57,5 @@ $allowedApplicationEnvs = [
 ];
 
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', getcwd());
-define('APPLICATION_ENV', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
-define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV !== 'prod');
+define('APPLICATION_ENV_SPRYK_USAGE', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
+define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV_SPRYK_USAGE !== 'prod');

--- a/bin/spryk
+++ b/bin/spryk
@@ -7,7 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 

--- a/bin/spryk-build
+++ b/bin/spryk-build
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:build', true);
 

--- a/bin/spryk-dump
+++ b/bin/spryk-dump
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:dump', true);
 

--- a/bin/spryk-run
+++ b/bin/spryk-run
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/APPS-4381

- Docs PR: ACADEMY_URL_HERE

- Release Group: URL_HERE

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykSrc              | patch (currently 0.0.x)  |                       |

-----------------------------------------

#### Module SprykSrc

##### Change log

### Improvements

- Added `APPLICATION_ENV` and `APPLICATION_DEBUG` constants to control the behavior of the Symfony Kernel.
- Improved `preSpryks` and `postSpryks` configuration.
- Added the possibility to use `spryks`  instead of `preSpryks` and `postSpryks` definitions in Wrapper Spryks.
- Allow resources to contain slashes (e.g. /foo/bar) in Glue Spryks.

### Fixes

- Use default `ArrayAdapter` as caching adapter for the Symfony ExpressionLanguage to prevent writing to the cache files within the `spryk.phar` which would cause an exception as it is not possible to write to a PHAR archive.

### Deprecations

- Deprecated `\SprykerSdk\Spryk\Model\Spryk\Filter\NormalizeResourceNameFilter`.