### PR TITLE
FRW-112: Fixed redeclared const issue

### DIFF
--- a/bin/environment.php
+++ b/bin/environment.php
@@ -57,5 +57,5 @@ $allowedApplicationEnvs = [
 ];
 
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', getcwd());
-define('APPLICATION_ENV_SPRYK_USAGE', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
-define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV_SPRYK_USAGE !== 'prod');
+define('APPLICATION_ENV_SPRYK', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
+define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV_SPRYK !== 'prod');

--- a/bin/environment.php
+++ b/bin/environment.php
@@ -57,5 +57,5 @@ $allowedApplicationEnvs = [
 ];
 
 defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', getcwd());
-define('APPLICATION_ENV', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
-define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV !== 'prod');
+define('APPLICATION_ENV_SPRYK_USAGE', $applicationEnv !== false && in_array($applicationEnv, $allowedApplicationEnvs, true) ? $applicationEnv : 'prod');
+define('APPLICATION_DEBUG', getenv('APPLICATION_DEBUG') !== false ? (bool)getenv('APPLICATION_DEBUG') : APPLICATION_ENV_SPRYK_USAGE !== 'prod');

--- a/bin/spryk
+++ b/bin/spryk
@@ -7,7 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 

--- a/bin/spryk
+++ b/bin/spryk
@@ -7,7 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 

--- a/bin/spryk-build
+++ b/bin/spryk-build
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:build', true);
 

--- a/bin/spryk-build
+++ b/bin/spryk-build
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:build', true);
 

--- a/bin/spryk-dump
+++ b/bin/spryk-dump
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:dump', true);
 

--- a/bin/spryk-dump
+++ b/bin/spryk-dump
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:dump', true);
 

--- a/bin/spryk-run
+++ b/bin/spryk-run
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 

--- a/bin/spryk-run
+++ b/bin/spryk-run
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 (function () {
     require_once __DIR__ . DIRECTORY_SEPARATOR . 'environment.php';
 
-    $kernel = new Kernel(APPLICATION_ENV_SPRYK_USAGE, APPLICATION_DEBUG);
+    $kernel = new Kernel(APPLICATION_ENV_SPRYK, APPLICATION_DEBUG);
     $application = new Application($kernel);
     $application->setDefaultCommand('spryk:run', true);
 

--- a/src/Spryk/Model/Spryk/Builder/AbstractBuilder.php
+++ b/src/Spryk/Model/Spryk/Builder/AbstractBuilder.php
@@ -256,7 +256,7 @@ abstract class AbstractBuilder implements SprykBuilderInterface
     /**
      * @param string $argumentName
      *
-     * @return array|string|int
+     * @return mixed
      */
     protected function getArgumentByName(string $argumentName)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddConstantVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddConstantVisitor.php
@@ -49,7 +49,7 @@ class AddConstantVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddExpressionToMethodBeforeReturnVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddExpressionToMethodBeforeReturnVisitor.php
@@ -40,7 +40,7 @@ class AddExpressionToMethodBeforeReturnVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|array|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddGlueResourceMethodVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddGlueResourceMethodVisitor.php
@@ -56,7 +56,7 @@ class AddGlueResourceMethodVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|array|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddImplementsVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddImplementsVisitor.php
@@ -32,7 +32,7 @@ class AddImplementsVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddMethodVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddMethodVisitor.php
@@ -33,7 +33,7 @@ class AddMethodVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|array|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddPluginToPluginListVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddPluginToPluginListVisitor.php
@@ -91,7 +91,7 @@ class AddPluginToPluginListVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddUseVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/AddUseVisitor.php
@@ -45,7 +45,7 @@ class AddUseVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|array<\PhpParser\Node>|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/OrderStatementsInClassVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/OrderStatementsInClassVisitor.php
@@ -22,7 +22,7 @@ class OrderStatementsInClassVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node|int|null
+     * @return mixed
      */
     public function enterNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Builder/NodeVisitor/ReplaceMethodBodyNodeVisitor.php
+++ b/src/Spryk/Model/Spryk/Builder/NodeVisitor/ReplaceMethodBodyNodeVisitor.php
@@ -36,7 +36,7 @@ class ReplaceMethodBodyNodeVisitor extends NodeVisitorAbstract
     /**
      * @param \PhpParser\Node $node
      *
-     * @return \PhpParser\Node\Stmt\ClassMethod|void
+     * @return mixed
      */
     public function leaveNode(Node $node)
     {

--- a/src/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
+++ b/src/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
@@ -283,7 +283,7 @@ class ArgumentResolver implements ArgumentResolverInterface
      * @param string|int|null $default
      * @param bool $allowEmpty
      *
-     * @return string|int|null
+     * @return mixed
      */
     protected function askForArgumentValue(string $argument, string $sprykName, $default, bool $allowEmpty = false)
     {
@@ -314,7 +314,7 @@ class ArgumentResolver implements ArgumentResolverInterface
      * @param array<string>|array<int>|array<null> $values
      * @param string|int|null $default
      *
-     * @return string|int|null
+     * @return mixed
      */
     protected function choseArgumentValue(string $argument, string $sprykName, array $values, $default)
     {

--- a/src/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
+++ b/src/Spryk/Model/Spryk/Definition/Argument/Resolver/ArgumentResolver.php
@@ -280,7 +280,7 @@ class ArgumentResolver implements ArgumentResolverInterface
     /**
      * @param string $argument
      * @param string $sprykName
-     * @param string|int|null $default
+     * @param mixed $default
      * @param bool $allowEmpty
      *
      * @return mixed
@@ -312,7 +312,7 @@ class ArgumentResolver implements ArgumentResolverInterface
      * @param string $argument
      * @param string $sprykName
      * @param array<string>|array<int>|array<null> $values
-     * @param string|int|null $default
+     * @param mixed $default
      *
      * @return mixed
      */

--- a/src/Spryk/Model/Spryk/Definition/Argument/Superseder/Superseder.php
+++ b/src/Spryk/Model/Spryk/Definition/Argument/Superseder/Superseder.php
@@ -99,11 +99,11 @@ class Superseder implements SupersederInterface
     }
 
     /**
-     * @param string|int|bool $argumentValue
+     * @param mixed $argumentValue
      * @param \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\Collection\ArgumentCollectionInterface $sprykArguments
      * @param \SprykerSdk\Spryk\Model\Spryk\Definition\Argument\Collection\ArgumentCollectionInterface $resolvedArguments
      *
-     * @return string|int|bool
+     * @return mixed
      */
     protected function replacePlaceholderInValue(
         $argumentValue,

--- a/src/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilder.php
+++ b/src/Spryk/Model/Spryk/Definition/Builder/SprykDefinitionBuilder.php
@@ -518,7 +518,7 @@ class SprykDefinitionBuilder implements SprykDefinitionBuilderInterface
     }
 
     /**
-     * @param array|string $sprykInfo
+     * @param mixed $sprykInfo
      * @param string $parentSprykDefinitionKey
      *
      * @return \SprykerSdk\Spryk\Model\Spryk\Definition\SprykDefinitionInterface|null

--- a/src/Spryk/Style/InputHelper.php
+++ b/src/Spryk/Style/InputHelper.php
@@ -25,7 +25,7 @@ trait InputHelper
     /**
      * @param \Symfony\Component\Console\Question\Question $question
      *
-     * @return string|int|null
+     * @return mixed
      */
     public function askQuestion(Question $question)
     {

--- a/src/Spryk/Style/SprykStyle.php
+++ b/src/Spryk/Style/SprykStyle.php
@@ -192,7 +192,7 @@ class SprykStyle implements SprykStyleInterface
     }
 
     /**
-     * @param array<string>|string $messages
+     * @param mixed $messages
      * @param int $options
      *
      * @return void
@@ -261,7 +261,7 @@ class SprykStyle implements SprykStyleInterface
     }
 
     /**
-     * @param array<string>|string $messages
+     * @param mixed $messages
      * @param int $options
      *
      * @return void

--- a/src/Spryk/Style/SprykStyleInterface.php
+++ b/src/Spryk/Style/SprykStyleInterface.php
@@ -110,7 +110,7 @@ interface SprykStyleInterface
     public function endPostSpryks(SprykDefinitionInterface $sprykDefinition): void;
 
     /**
-     * @param array<string>|string $messages
+     * @param mixed $messages
      * @param int $options
      *
      * @return void
@@ -118,7 +118,7 @@ interface SprykStyleInterface
     public function write($messages, int $options = 0): void;
 
     /**
-     * @param array<string>|string $messages
+     * @param mixed $messages
      * @param int $options
      *
      * @return void
@@ -128,7 +128,7 @@ interface SprykStyleInterface
     /**
      * @param \Symfony\Component\Console\Question\Question $question
      *
-     * @return string|int|null
+     * @return mixed
      */
     public function askQuestion(Question $question);
 

--- a/tests/_support/Module/SprykHelper.php
+++ b/tests/_support/Module/SprykHelper.php
@@ -187,7 +187,7 @@ class SprykHelper extends Module
     /**
      * @return \SprykerSdk\Spryk\SprykConfig|object
      */
-    protected function getSprykConfigMock()
+    protected function getSprykConfigMock(): SprykConfig
     {
         $sprykConfig = Stub::make(SprykConfig::class, [
             'getProjectRootDirectory' => function () {


### PR DESCRIPTION
- Developer(s): @olhalivitchuk 

- Ticket: https://spryker.atlassian.net/browse/FRW-112

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykSrc              | patch (currently 0.0.x)  |                       |

-----------------------------------------

#### Module SprykSrc

##### Change log

### Fixes

- Added `APPLICATION_ENV_SPRYK_USAGE` instead of redeclaring `APPLICATION_ENV` so it does not throw the exception if the constant has been already defined.